### PR TITLE
 Make a release type of refactoring 'patch'

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "rinse",
   "name": "@rinse/git-bump",
   "description": "Bump a version of the project.",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "main": "build/index.js",
   "types": "build/index.d.js",
   "bin": {

--- a/src/keywords.ts
+++ b/src/keywords.ts
@@ -33,13 +33,13 @@ const Keywords = {
     "feat!": "major",
     "feature": "minor",
     "feature!": "major",
-    "refactor": "minor",
+    "refactor": "patch",
     "refactor!": "major",
-    "refactors": "minor",
+    "refactors": "patch",
     "refactors!": "major",
-    "refactored": "minor",
+    "refactored": "patch",
     "refactored!": "major",
-    "refactoring": "minor",
+    "refactoring": "patch",
     "refactoring!": "major",
 } as const;
 


### PR DESCRIPTION
リファクタリングのリリースタイプを minor から patch に変更した。

リファクタリングによって新たなバグが追加されてしまう可能性があるが、新規機能を追加するわけではない
